### PR TITLE
Fix MessageCache and further Bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Test.java
 config/messageCaching.properties
 config/test.properties
 latest.log.lck
+config/messageSystem.properties

--- a/API/src/main/java/net/juligames/core/api/jdbi/SQLManager.java
+++ b/API/src/main/java/net/juligames/core/api/jdbi/SQLManager.java
@@ -3,9 +3,12 @@ package net.juligames.core.api.jdbi;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.result.ResultIterable;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.sql.Connection;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
  * @author Ture Bentzin
@@ -39,6 +42,19 @@ public interface SQLManager {
      * @see Jdbi#open()
      */
     Handle openHandle();
+
+    /**
+     * You can use this to execute stuff on JDBI fast and secure
+     * @return a new Handle
+     * @see SQLManager#openHandle()
+     */
+    <R> R useHandle(Function<Handle,R> handleFunction);
+
+    @ApiStatus.Experimental
+    ResultIterable<Map<String, Object>> mapQuery(String sql);
+
+    @ApiStatus.Experimental
+    <T> ResultIterable<Map<String, T>> mapDefinedQuery(String sql, Class<T> valueClass);
 
     /**
      * @param connection connection to use

--- a/API/src/main/java/net/juligames/core/api/message/MessageApi.java
+++ b/API/src/main/java/net/juligames/core/api/message/MessageApi.java
@@ -137,7 +137,7 @@ public interface MessageApi {
 
     Collection<MessagePostScript> sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients);
 
-    MultiMessagePostScript> sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, String overrideLocale);
+    MultiMessagePostScript sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, String overrideLocale);
     MultiMessagePostScript sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, Locale overrideLocale);
     MultiMessagePostScript sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, DBLocale overrideLocale);
 

--- a/API/src/main/java/net/juligames/core/api/message/MessageApi.java
+++ b/API/src/main/java/net/juligames/core/api/message/MessageApi.java
@@ -3,6 +3,7 @@ package net.juligames.core.api.message;
 import net.juligames.core.api.jdbi.*;
 import org.jdbi.v3.core.extension.ExtensionCallback;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.Locale;
@@ -132,6 +133,21 @@ public interface MessageApi {
 
     MultiMessagePostScript sendMessage(Collection<String> messageKeys, Collection<? extends MessageRecipient> messageRecipients, DBLocale overrideLocale);
 
+    Collection<MultiMessagePostScript> sendMessageSmart(@NotNull Collection<String> messageKeys, Collection<? extends MessageRecipient> messageRecipients, String... replacement);
+
+    Collection<MessagePostScript> sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients);
+
+    MultiMessagePostScript> sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, String overrideLocale);
+    MultiMessagePostScript sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, Locale overrideLocale);
+    MultiMessagePostScript sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, DBLocale overrideLocale);
+
+    Collection<MessagePostScript> sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, String... replacements);
+
+    MultiMessagePostScript sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, String overrideLocale, String... replacements);
+    MultiMessagePostScript sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, Locale overrideLocale, String... replacements);
+    MultiMessagePostScript sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, DBLocale overrideLocale, String... replacements);
+
+
     MultiMessagePostScript broadcastMessage(Collection<String> messageKeys, Locale defaultLocale);
 
     MultiMessagePostScript broadcastMessage(Collection<String> messageKeys, String defaultLocale);
@@ -159,6 +175,10 @@ public interface MessageApi {
 
     MultiMessagePostScript sendMessage(Collection<String> messageKeys, MessageRecipient messageRecipient, String... replacement);
 
+    /**
+     * @deprecated use {@link MessageApi#sendMessageSmart(Collection, Collection, String...)} instead
+     */
+    @Deprecated
     MultiMessagePostScript sendMessage(Collection<String> messageKeys, Collection<? extends MessageRecipient> messageRecipients, String... replacement);
 
     MultiMessagePostScript sendMessage(Collection<String> messageKeys, MessageRecipient messageRecipient, String overrideLocale, String... replacement);

--- a/AdventureCore/src/main/java/net/juligames/core/adventure/BlankTag.removed
+++ b/AdventureCore/src/main/java/net/juligames/core/adventure/BlankTag.removed
@@ -1,0 +1,65 @@
+package net.juligames.core.adventure;
+
+import de.bentzin.tools.pair.Pair;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.PatternReplacementResult;
+import net.kyori.adventure.text.TextReplacementConfig;
+import net.kyori.adventure.text.minimessage.internal.parser.Token;
+import net.kyori.adventure.text.minimessage.internal.parser.TokenType;
+import net.kyori.adventure.text.minimessage.internal.parser.node.CheatNode;
+import net.kyori.adventure.text.minimessage.internal.parser.node.ElementNode;
+import net.kyori.adventure.text.minimessage.internal.parser.node.TagNode;
+import net.kyori.adventure.text.minimessage.internal.parser.node.TextNode;
+import net.kyori.adventure.text.minimessage.internal.parser.node.ValueNode;
+import net.kyori.adventure.text.minimessage.tag.Modifying;
+import net.kyori.adventure.text.minimessage.tree.Node;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.StringJoiner;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+
+/**
+ * @author Ture Bentzin
+ * 04.02.2023
+ */
+public class BlankTag implements Modifying {
+
+    private Collection<Pair<Integer>> ranges = new HashSet<>();
+    private int memory = 0;
+
+    @Override
+    public void visit(@NotNull Node current, int depth) {
+
+        if(current instanceof ElementNode elementNode) {
+            System.out.println(elementNode.token().toString() + " " + elementNode.sourceMessage());
+        }
+        if(current instanceof TagNode tagNode)
+        {
+
+            if(tagNode.tag() instanceof BlankTag blankTag) {
+                //it's my tag!
+                StringJoiner joiner = new StringJoiner("");
+
+                tagNode.children().forEach(elementNode -> {
+                    if(elementNode instanceof TextNode textNode) {
+                        joiner.add(textNode.value());
+                    }
+                });
+
+                tagNode.unsafeChildren().clear();
+                Token token = tagNode.token();
+                tagNode.addChild(new CheatNode(tagNode,token,tagNode.sourceMessage(),joiner.toString()));
+                System.out.println(joiner);
+            }
+        }
+    }
+
+    @Override
+    public Component apply(@NotNull Component current, int depth) {
+        return current;
+    }
+}

--- a/AdventureCore/src/main/java/net/juligames/core/adventure/CoreAdventureTagManager.java
+++ b/AdventureCore/src/main/java/net/juligames/core/adventure/CoreAdventureTagManager.java
@@ -9,6 +9,7 @@ import net.juligames.core.api.message.TagManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
@@ -75,7 +76,7 @@ public final class CoreAdventureTagManager implements TagManager, AdventureTagMa
 
     @Override
     public @NotNull Component resolve(@NotNull Message message) {
-        return getMiniMessage().deserialize(message.getMiniMessage(), getResolver());
+        return getMiniMessage().deserialize(message.getMiniMessage(), getResolver()); // https://docs.adventure.kyori.net/minimessage/dynamic-replacements.html#insert-some-unparsed-text
     }
 
     @Override

--- a/AdventureCore/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/CheatNode.java
+++ b/AdventureCore/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/CheatNode.java
@@ -1,0 +1,29 @@
+package net.kyori.adventure.text.minimessage.internal.parser.node;
+
+import net.kyori.adventure.text.minimessage.internal.parser.Token;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @author Ture Bentzin
+ * 04.02.2023
+ */
+public class CheatNode extends ValueNode{
+    /**
+     * Creates a new element node.
+     *
+     * @param parent        the parent of this node
+     * @param token         the token that created this node
+     * @param sourceMessage the source message
+     * @param value         the value of this text node
+     * @since 4.10.0
+     */
+    public CheatNode(@Nullable ElementNode parent, @Nullable Token token, @NotNull String sourceMessage, @NotNull String value) {
+        super(parent, token, sourceMessage, value);
+    }
+
+    @Override
+    String valueName() {
+        return "TextNode";
+    }
+}

--- a/Core/src/main/java/net/juligames/core/Core.java
+++ b/Core/src/main/java/net/juligames/core/Core.java
@@ -152,7 +152,7 @@ public final class Core implements API {
         coreNotificationApi = new CoreNotificationApi();
         coreCommandApi = new CoreCommandApi();
         clusterApi = new CoreClusterApi();
-        messageApi = new CoreMessageApi();
+        messageApi = new CoreMessageApi(); //needs to be called AFTER configurationAPI
         coreCacheApi = new CoreCacheApi();
         basicMiniGame = new SubscribableType<>();
 

--- a/Core/src/main/java/net/juligames/core/caching/CoreCacheApi.java
+++ b/Core/src/main/java/net/juligames/core/caching/CoreCacheApi.java
@@ -12,6 +12,7 @@ import net.juligames.core.api.jdbi.DBMessage;
  */
 public class CoreCacheApi implements CacheApi {
 
+    //This will be extended to read from configuration later, if good defaults are collected
 
     @Override
     public <K, V> Cache<K, V> newCache() {

--- a/Core/src/main/java/net/juligames/core/command/inbuild/ShutdownCommand.java
+++ b/Core/src/main/java/net/juligames/core/command/inbuild/ShutdownCommand.java
@@ -1,8 +1,13 @@
 package net.juligames.core.command.inbuild;
 
+import net.juligames.core.api.TODO;
+
+
+//TODO Inbuilt core Commands that are handled separately from normal commands
 /**
  * @author Ture Bentzin
  * 17.01.2023
  */
+@TODO(doNotcall = true)
 public class ShutdownCommand {
 }

--- a/Core/src/main/java/net/juligames/core/jdbi/CoreSQLManager.java
+++ b/Core/src/main/java/net/juligames/core/jdbi/CoreSQLManager.java
@@ -9,12 +9,15 @@ import net.juligames.core.api.jdbi.mapper.bean.LocaleBean;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.result.ResultIterable;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.sql.Connection;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
  * @author Ture Bentzin
@@ -127,6 +130,23 @@ public class CoreSQLManager implements SQLManager {
     @Override
     public Handle openHandle() {
         return getJdbi().open();
+    }
+
+    @Override
+    public <R> R useHandle(@NotNull Function<Handle, R> handleFunction) {
+        try(Handle handle = openHandle()) {
+            return handleFunction.apply(handle);
+        }
+    }
+
+    @Override
+    public ResultIterable<Map<String, Object>> mapQuery(String sql) {
+        return useHandle(handle -> handle.createQuery(sql).mapToMap());
+    }
+
+    @Override
+    public <T> ResultIterable<Map<String, T>> mapDefinedQuery(String sql, Class<T> valueClass) {
+        return useHandle(handle -> handle.createQuery(sql).mapToMap(valueClass));
     }
 
     @Override

--- a/Core/src/main/java/net/juligames/core/message/CoreMessage.java
+++ b/Core/src/main/java/net/juligames/core/message/CoreMessage.java
@@ -18,7 +18,7 @@ public class CoreMessage implements Message {
     private final DBMessage messageData;
 
     public CoreMessage(@NotNull DBMessage messageData) {
-        this.messageData = messageData;
+        this.messageData = messageData.clone(); //clone to avoid conflicts
     }
 
     @Contract("_, _ -> new")

--- a/Core/src/main/java/net/juligames/core/message/CoreMessageApi.java
+++ b/Core/src/main/java/net/juligames/core/message/CoreMessageApi.java
@@ -344,8 +344,13 @@ public class CoreMessageApi implements MessageApi {
     }
 
     @Override
-    public CoreMultiMessagePostScript sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, Locale overrideLocale) {
+    public CoreMultiMessagePostScript sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, String overrideLocale) {
         return sendMessage(List.of(messageKey),messageRecipients,overrideLocale);
+    }
+
+    @Override
+    public CoreMultiMessagePostScript sendMessage(String messageKey, Collection<? extends MessageRecipient> messageRecipients, Locale overrideLocale) {
+        return sendMessage(messageKey,messageRecipients,overrideLocale.toString());
     }
 
     @Override

--- a/Core/src/main/java/net/juligames/core/message/CoreMessageApi.java
+++ b/Core/src/main/java/net/juligames/core/message/CoreMessageApi.java
@@ -116,7 +116,9 @@ public class CoreMessageApi implements MessageApi {
     @Override
     public CoreMessage getMessage(String messageKey, String locale, String... replacements) {
         CoreMessage message = getMessage(messageKey, locale);
+        Core.getInstance().getCoreLogger().debug("inserting replacements: " + Arrays.toString(replacements) + " to " + message.getMiniMessage()  + "@" + message.getMessageData().getMessageKey());
         message.doWithMiniMessage(insertReplacements(replacements));
+        Core.getInstance().getCoreLogger().debug("new Data: " + message.getMiniMessage());
         return message;
     }
 
@@ -670,21 +672,21 @@ public class CoreMessageApi implements MessageApi {
     public Message findBestMessage(String messageKey, String locale,@Nullable String... replacements) {
         Message message;
         if(replacements == null) {
-            message = API.get().getMessageApi().getMessage(messageKey, locale);
+            message = getMessage(messageKey, locale);
         }else
-            message = API.get().getMessageApi().getMessage(messageKey, locale, replacements);
+            message = getMessage(messageKey, locale, replacements);
 
-        checkLocale(locale);
+        checkLocale(locale); //May kill here in the future
         if (message instanceof FallBackMessage) {
             //fallback = not present
-            if (!Objects.equals(locale, defaultLocale())) {
+            if (!locale.equalsIgnoreCase(defaultLocale())) {
                 if (locale.contains("_")) {
                     //can go "deeper"
-                    return findBestMessage(messageKey, reduce(locale));
+                    return findBestMessage(messageKey, reduce(locale),replacements);
                 }
             }
             //use defaultLocale or fallback...
-            return getMessage(messageKey,defaultLocale());
+            return getMessage(messageKey,defaultLocale(),replacements);
 
         } else {
             //Message is present...

--- a/Core/src/main/java/net/juligames/core/message/CoreMessageApi.java
+++ b/Core/src/main/java/net/juligames/core/message/CoreMessageApi.java
@@ -681,7 +681,8 @@ public class CoreMessageApi implements MessageApi {
         if(dbMessage == null) {
             return null;
         }
-        getMessageCache().put(new Pair<>(dbMessage.getMessageKey(), dbMessage.getLocale()), dbMessage);
+        if(getMessageCache() != null)
+         getMessageCache().put(new Pair<>(dbMessage.getMessageKey(), dbMessage.getLocale()), dbMessage);
         return dbMessage;
     }
 

--- a/Core/src/main/java/net/juligames/core/message/CoreMessageApi.java
+++ b/Core/src/main/java/net/juligames/core/message/CoreMessageApi.java
@@ -583,7 +583,7 @@ public class CoreMessageApi implements MessageApi {
     }
 
     @Contract(pure = true)
-    private @NotNull Function<String, String> insertReplacements(@Nullable String @NotNull ... replacements) {
+    private @NotNull Function<String, String> insertReplacements(@Nullable String ... replacements) {
         //noinspection ConstantConditions for 100% security
         if (replacements == null) {
             return miniMessage -> miniMessage;
@@ -591,7 +591,13 @@ public class CoreMessageApi implements MessageApi {
         return miniMessage -> {
             Core.getInstance().getCoreLogger().debug("insert start: " + miniMessage);
             for (int i = 0; i < replacements.length; i++) {
-                assert replacements[i] != null;
+                if(replacements[i] == null) replacements[i] = "null";
+                /* if(replacements[i].contains("</blank>")) {
+                    Core.getInstance().getCoreLogger().warning("detected illegal </blank> in replacer! " + replacements[i] +
+                            " at [" + i +"]"  + " for message \"" + miniMessage + "\" ");
+                }
+                 */
+               //TODO replacements[i] = replacements[i].replace("</blank>","blank");
                 miniMessage = miniMessage.replace(buildPattern(i), replacements[i]);
                 Core.getInstance().getCoreLogger().debug("insert step: " + i + " :" + miniMessage);
             }

--- a/Core/src/main/java/net/juligames/core/message/CoreMessageApi.java
+++ b/Core/src/main/java/net/juligames/core/message/CoreMessageApi.java
@@ -695,7 +695,7 @@ public class CoreMessageApi implements MessageApi {
     @ApiStatus.Internal
     private void checkLocale(@NotNull String locale) {
         final int maxLocaleLength = MessageConfigManager.getMaxLocaleLength();
-        if(locale.chars().mapToObj(i -> (char) i).count() > maxLocaleLength) {
+        if(locale.chars().mapToObj(i -> (char) i).filter(c -> c.equals('_')).count() > maxLocaleLength) {
             if(MessageConfigManager.getWarnOnInvalidLocale())
                 Core.getInstance().getCoreLogger().warning("malformed locale that exceeds maximum length of " + maxLocaleLength + " : "+ locale);
             if(MessageConfigManager.getThrowOnInvalidLocale())

--- a/Core/src/main/java/net/juligames/core/message/MessageConfigManager.java
+++ b/Core/src/main/java/net/juligames/core/message/MessageConfigManager.java
@@ -1,0 +1,46 @@
+package net.juligames.core.message;
+
+import net.juligames.core.api.API;
+import net.juligames.core.api.config.Configuration;
+
+import java.util.Properties;
+
+/**
+ * @author Ture Bentzin
+ * 02.02.2023
+ */
+public final class MessageConfigManager {
+
+    private MessageConfigManager(){}
+
+    private static final String name = "messageSystem";
+
+    public static void init() {
+        Properties properties = new Properties();
+        properties.setProperty("configuration_name", name);
+        properties.setProperty("max_locale_length", "3");
+        properties.setProperty("throw_on_invalid_locale", "false");
+        properties.setProperty("warn_on_invalid_locale", "true");
+        Configuration orCreate = API.get().getConfigurationApi().getOrCreate(properties);
+    }
+
+    public static Configuration configuration() {
+        return API.get().getConfigurationApi().getOrCreate(name);
+    }
+
+    public static String getName() {
+        return name;
+    }
+
+    public static int getMaxLocaleLength() {
+        return configuration().getInteger("max_locale_length").orElse(3);
+    }
+
+    public static boolean getThrowOnInvalidLocale(){
+        return configuration().getBoolean("throw_on_invalid_locale").orElse(false);
+    }
+
+    public static boolean getWarnOnInvalidLocale(){
+        return configuration().getBoolean("warn_on_invalid_locale").orElse(true);
+    }
+}

--- a/VelocityCore/dependency-reduced-pom.xml
+++ b/VelocityCore/dependency-reduced-pom.xml
@@ -21,7 +21,7 @@
           </execution>
         </executions>
         <configuration>
-          <createSourcesJar>true</createSourcesJar>
+          <createSourcesJar>false</createSourcesJar>
         </configuration>
       </plugin>
     </plugins>

--- a/VelocityCore/pom.xml
+++ b/VelocityCore/pom.xml
@@ -66,7 +66,7 @@
                 <version>3.4.1</version>
                 <configuration>
                     <!-- put your configurations here -->
-                    <createSourcesJar>true</createSourcesJar>
+                    <createSourcesJar>false</createSourcesJar>
                 </configuration>
                 <executions>
                     <execution>

--- a/config/messageSystem.properties
+++ b/config/messageSystem.properties
@@ -1,6 +1,0 @@
-#configuration_header written at: 2023-02-04 | 09:36:57
-#Sat Feb 04 09:36:57 CET 2023
-max_locale_length=3
-warn_on_invalid_locale=true
-throw_on_invalid_locale=false
-configuration_name=messageSystem

--- a/config/messageSystem.properties
+++ b/config/messageSystem.properties
@@ -1,0 +1,6 @@
+#configuration_header written at: 2023-02-04 | 09:36:57
+#Sat Feb 04 09:36:57 CET 2023
+max_locale_length=3
+warn_on_invalid_locale=true
+throw_on_invalid_locale=false
+configuration_name=messageSystem


### PR DESCRIPTION
### This is a Bug-fixing pull request, that fixes a lot of crucial bugs and glitches with the Core

Among these fixes are the following:

- NullPointerException if caching is disabled and somebody tries to cache stuff
- Fallbacks are now working as expected, with replaces in foreign languages
- Server lags with too large locale (fixed)
- Message API can't send messages to multiple recipients with replaces (fixed)
- replaces are not replaced after a language switch to a language that has no translation for the message in the database (fixed)